### PR TITLE
Update metainfo.xml for v0.7.0 release

### DIFF
--- a/app/io.github.cosmic_utils.minimon-applet/io.github.cosmic_utils.minimon-applet.json
+++ b/app/io.github.cosmic_utils.minimon-applet/io.github.cosmic_utils.minimon-applet.json
@@ -12,6 +12,7 @@
     "--socket=fallback-x11",
     "--filesystem=xdg-config/cosmic:rw",
     "--talk-name=com.system76.CosmicSettingsDaemon",
+    "--talk-name=org.freedesktop.Flatpak",
     "--filesystem=/sys/class/hwmon:ro",
     "--filesystem=/sys/class/drm:ro",
     "--filesystem=/sys/devices:ro",
@@ -46,7 +47,7 @@
         {
           "type": "git",
           "url": "https://github.com/cosmic-utils/minimon-applet.git",
-          "commit": "21a2ddfcd04e89a526918ae52af442c8cbac248f"
+          "commit": "6d4129f8dd6db616c85194362e5d296b25882374"
         },
         "cargo-sources.json"
       ]


### PR DESCRIPTION
Update to release [v0.7.0](https://github.com/cosmic-utils/minimon-applet/releases/tag/v0.7.0)

This adds one more permission to finish-args" ```--talk-name=org.freedesktop.Flatpak```. The purpose of which being to use ```flatpak-spawn --host``` to search for System Monitor applications amongst the hosts ".desktop" files and launch the selected one upon request, using gtk4-launch (with shell fallback). This fixes the bug where no System Monitors were found for the Flatpak version.

I added a discrete tipping button that will open the system browser with XDG-OPEN to my [ko-fi page](https://ko-fi.com/hyperchaotic). Please advice whether this is in line with guidelines for this repo? If it's not in the spirit of the repo I'll remove it.

<img width="513" height="248" alt="heart" src="https://github.com/user-attachments/assets/0375ef4a-8ece-4d85-acfd-85741c6710e4" />
