### PR TITLE
fix: vigil/pomodoro applets runtime version, build-commands

### DIFF
--- a/app/com.github.bgub.CosmicExtAppletPomodoro/com.github.bgub.CosmicExtAppletPomodoro.json
+++ b/app/com.github.bgub.CosmicExtAppletPomodoro/com.github.bgub.CosmicExtAppletPomodoro.json
@@ -1,7 +1,7 @@
 {
   "id": "com.github.bgub.CosmicExtAppletPomodoro",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "24.08",
+  "runtime-version": "25.08",
   "base": "com.system76.Cosmic.BaseApp",
   "base-version": "stable",
   "sdk": "org.freedesktop.Sdk",
@@ -24,8 +24,12 @@
       "name": "cosmic-ext-applet-pomodoro",
       "buildsystem": "simple",
       "build-commands": [
-        "just build-release --verbose --offline",
-        "just prefix=/app install"
+        "cargo --offline fetch --manifest-path Cargo.toml --verbose",
+        "cargo --offline build --release --verbose",
+        "install -Dm0755 ./target/release/cosmic-ext-applet-pomodoro /app/bin/cosmic-ext-applet-pomodoro",
+        "install -Dm0644 ./resources/app.desktop /app/share/applications/com.github.bgub.CosmicExtAppletPomodoro.desktop",
+        "install -Dm0644 ./resources/app.metainfo.xml /app/share/metainfo/com.github.bgub.CosmicExtAppletPomodoro.metainfo.xml",
+        "install -Dm0644 ./resources/icon.svg /app/share/icons/hicolor/scalable/apps/com.github.bgub.CosmicExtAppletPomodoro.svg"
       ],
       "sources": [
         {

--- a/app/com.github.bgub.CosmicExtAppletVigil/com.github.bgub.CosmicExtAppletVigil.json
+++ b/app/com.github.bgub.CosmicExtAppletVigil/com.github.bgub.CosmicExtAppletVigil.json
@@ -1,7 +1,7 @@
 {
   "id": "com.github.bgub.CosmicExtAppletVigil",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "24.08",
+  "runtime-version": "25.08",
   "base": "com.system76.Cosmic.BaseApp",
   "base-version": "stable",
   "sdk": "org.freedesktop.Sdk",
@@ -25,8 +25,12 @@
       "name": "cosmic-ext-applet-vigil",
       "buildsystem": "simple",
       "build-commands": [
-        "just build-release --verbose --offline",
-        "just prefix=/app install"
+        "cargo --offline fetch --manifest-path Cargo.toml --verbose",
+        "cargo --offline build --release --verbose",
+        "install -Dm0755 ./target/release/cosmic-ext-applet-vigil /app/bin/cosmic-ext-applet-vigil",
+        "install -Dm0644 ./resources/app.desktop /app/share/applications/com.github.bgub.CosmicExtAppletVigil.desktop",
+        "install -Dm0644 ./resources/app.metainfo.xml /app/share/metainfo/com.github.bgub.CosmicExtAppletVigil.metainfo.xml",
+        "install -Dm0644 ./resources/icon.svg /app/share/icons/hicolor/scalable/apps/com.github.bgub.CosmicExtAppletVigil.svg"
       ],
       "sources": [
         {


### PR DESCRIPTION
I'm sorry it's taking so many tries to get this right. I built each flatpak locally this time and triple-checked against all the other applets. I'm pretty sure everything is correct -- hopefully third time's the charm!

## TL;DR
- Bump `runtime-version` from `24.08` to `25.08` for Vigil and Pomodoro applets. The 24.08 SDK ships rustc 1.89, but the pinned libcosmic commit (`03d0171`) requires `rust-version = "1.90"`
- Replace `just` build-commands with explicit `cargo`/`install` commands

## Verification

- Built both applets successfully locally