### PR TITLE
fix: update Pomodoro and Vigil applets to 0.1.2

### DIFF
--- a/app/com.github.bgub.CosmicExtAppletPomodoro/com.github.bgub.CosmicExtAppletPomodoro.json
+++ b/app/com.github.bgub.CosmicExtAppletPomodoro/com.github.bgub.CosmicExtAppletPomodoro.json
@@ -35,8 +35,8 @@
         {
           "type": "git",
           "url": "https://github.com/cosmic-utils/cosmic-ext-applet-pomodoro.git",
-          "tag": "0.1.1",
-          "commit": "98dc404fb552815541f3939cfa18db0e7d02c132"
+          "tag": "0.1.2",
+          "commit": "eaadeca0f88c2e602fb00ede7ea1bee6ca7760f5"
         },
         "cargo-sources.json"
       ]

--- a/app/com.github.bgub.CosmicExtAppletVigil/com.github.bgub.CosmicExtAppletVigil.json
+++ b/app/com.github.bgub.CosmicExtAppletVigil/com.github.bgub.CosmicExtAppletVigil.json
@@ -36,8 +36,8 @@
         {
           "type": "git",
           "url": "https://github.com/cosmic-utils/cosmic-ext-applet-vigil.git",
-          "tag": "0.1.1",
-          "commit": "bf871c2227dca8a13b49cd200e75058c595cb321"
+          "tag": "0.1.2",
+          "commit": "6dbbdffb011569c397fa1f59221ffc95d443e4e5"
         },
         "cargo-sources.json"
       ]


### PR DESCRIPTION
Hopefully this is the last fix PR for a while!

## Summary

Bump both applets to 0.1.2, which fixes two issues:

1. **Panel crash**: Desktop files had `%F` field code, causing flatpak to add `--file-forwarding` with `@@` markers. cosmic-panel's argument insertion placed `--socket=inherit-wayland-socket` inside the forwarding block, so flatpak treated it as a file path → crash on launch.
2. **Appstream validation**: The Dymkom translation PRs added `<description xml:lang="uk">` as a separate element, but appstreamcli requires translated `<p>` tags inside the single `<description>` element.