### PR TITLE
fix(SystemMonitor): toolchain version error

### DIFF
--- a/app/dev.DBrox.CosmicSystemMonitor/dev.DBrox.CosmicSystemMonitor.json
+++ b/app/dev.DBrox.CosmicSystemMonitor/dev.DBrox.CosmicSystemMonitor.json
@@ -1,7 +1,7 @@
 {
   "id": "dev.DBrox.CosmicSystemMonitor",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "24.08",
+  "runtime-version": "25.08",
   "sdk": "org.freedesktop.Sdk",
   "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
   "base": "com.system76.Cosmic.BaseApp",


### PR DESCRIPTION
The extension probably didn't compile in the CI for the last 2 releases, since I switched it to rust 1.90 around that time. The 25.08 runtime toolchain supports up to rust 1.95