### PR TITLE
Add io.github.PSGtatitos.papyrus (Papyrus animated wallpaper manager)

### DIFF
--- a/app/io.github.PSGtatitos.papyrus/io.github.PSGtatitos.papyrus.json
+++ b/app/io.github.PSGtatitos.papyrus/io.github.PSGtatitos.papyrus.json
@@ -1,0 +1,134 @@
+{
+    "id": "io.github.PSGtatitos.papyrus",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "25.08",
+    "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "base": "com.system76.Cosmic.BaseApp",
+    "base-version": "stable",
+    "command": "papyrus",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=wayland",
+        "--device=dri",
+        "--share=network",
+        "--filesystem=home",
+        "--filesystem=xdg-config/cosmic:rw"
+    ],
+    "modules": [
+        {
+            "name": "libplacebo",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dvulkan=disabled",
+                "-Dglslang=disabled",
+                "-Ddemos=false",
+                "--libdir=/app/lib"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://code.videolan.org/videolan/libplacebo.git",
+                    "tag": "v7.349.0",
+                    "disable-submodules": false
+                }
+            ]
+        },
+        {
+            "name": "libass",
+            "config-opts": [
+                "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libass/libass/releases/download/0.17.3/libass-0.17.3.tar.xz",
+                    "sha256": "eae425da50f0015c21f7b3a9c7262a910f0218af469e22e2931462fed3c50959"
+                }
+            ]
+        },
+        {
+            "name": "libmpv",
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig"
+            ],
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dlibmpv=true",
+                "-Dcplayer=false",
+                "-Dbuild-date=false",
+                "-Dalsa=disabled",
+                "--libdir=/app/lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/mpv-player/mpv/archive/refs/tags/v0.38.0.tar.gz",
+                    "sha256": "86d9ef40b6058732f67b46d0bbda24a074fae860b3eaae05bab3145041303066"
+                }
+            ]
+        },
+        {
+            "name": "mpvpaper",
+            "buildsystem": "meson",
+            "config-opts": [
+                "--prefix=/app"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/GhostNaN/mpvpaper.git",
+                    "branch": "master"
+                }
+            ]
+        },
+        {
+            "name": "python3-pybind11",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --find-links=file://${PWD} --no-build-isolation --prefix=/app pybind11-2.13.6.tar.gz"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/source/p/pybind11/pybind11-2.13.6.tar.gz",
+                    "sha256": "ba6af10348c12b24e92fa086b39cfba0eff619b61ac77c406167d813b096d39a"
+                }
+            ]
+        },
+        {
+            "name": "python3-pillow",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --find-links=file://${PWD} --no-build-isolation --prefix=/app pillow-12.2.0.tar.gz"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz",
+                    "sha256": "a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5"
+                }
+            ]
+        },
+        {
+            "name": "papyrus",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm755 papyrus.py /app/bin/papyrus",
+                "install -Dm644 io.github.PSGtatitos.papyrus.desktop /app/share/applications/io.github.PSGtatitos.papyrus.desktop",
+                "install -Dm644 assets/icon.png /app/share/icons/hicolor/256x256/apps/io.github.PSGtatitos.papyrus.png",
+                "install -Dm644 io.github.PSGtatitos.papyrus.metainfo.xml /app/share/metainfo/io.github.PSGtatitos.papyrus.metainfo.xml"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/PSGtatitos/papyrus.git",
+                    "branch": "main"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### What is this app?

Papyrus is a free, open-source animated wallpaper manager designed for Pop!_OS COSMIC. It lets users pick any video file and set it as a live animated wallpaper, with no accounts, no telemetry, and no Wallpaper Engine required.

It also automatically extracts the dominant accent color from the wallpaper and applies it to the COSMIC desktop theme, so the entire DE matches the wallpaper's color palette.

### Features

- Animated wallpapers from MP4, WebM, MKV, AVI and MOV files
- Auto-theme — extracts accent color and applies it to COSMIC live
- Auto dark/light mode based on wallpaper brightness
- Start on login toggle
- No telemetry, no accounts, no cloud

### Technical details

- Built with Python 3, GTK4 and libadwaita
- Uses mpvpaper for Wayland layer surface rendering
- Uses Pillow for thumbnail generation and color extraction
- Writes directly to COSMIC compiled theme config files for live accent color updates
- Config stored as plain JSON at ~/.config/papyrus/config.json

### License

GPL-3.0-or-later — same license as mpvpaper

### Links

- GitHub: https://github.com/PSGtatitos/papyrus
- Issues: https://github.com/PSGtatitos/papyrus/issues