### PR TITLE
Fixes PSGtatitos/papyrus#3 — PyGObject was not bundled in the Flatpak, causing ModuleNotFoundError: No module named 'gi' on launch.

### DIFF
--- a/app/io.github.PSGtatitos.papyrus/io.github.PSGtatitos.papyrus.json
+++ b/app/io.github.PSGtatitos.papyrus/io.github.PSGtatitos.papyrus.json
@@ -86,6 +86,21 @@
             ]
         },
         {
+            "name": "python3-pygobject",
+            "buildsystem": "meson",
+            "config-opts": [
+                "--prefix=/app",
+                "-Dpycairo=disabled"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/pygobject/3.50/pygobject-3.50.0.tar.xz",
+                    "sha256": "8d836e75b5a881d457ee1622cae4a32bcdba28a0ba562193adb3bbb472472212"
+                }
+            ]
+        },
+        {
             "name": "python3-pybind11",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
Fixed the ModuleNotFoundError 