### PR TITLE
feat: update Clippy Land to v0.5.2

### DIFF
--- a/app/io.github.k33wee.clippy-land/io.github.k33wee.clippy-land.json
+++ b/app/io.github.k33wee.clippy-land/io.github.k33wee.clippy-land.json
@@ -31,6 +31,7 @@
         "cargo build --locked --offline --release --verbose",
         "install -Dm0755 target/release/cosmic-applet-clippy-land /app/bin/cosmic-applet-clippy-land",
         "install -Dm0755 resources/cosmic-applet-clippy-land.sh /app/bin/cosmic-applet-clippy-land.sh",
+        "sh scripts/render-debug-wrapper.sh resources/cosmic-applet-clippy-land-debug.sh.in /app/bin/cosmic-applet-clippy-land /app/bin/cosmic-applet-clippy-land-debug.sh",
         "install -Dm0644 resources/io.github.k33wee.clippy-land.desktop /app/share/applications/io.github.k33wee.clippy-land.desktop",
         "install -Dm0644 resources/io.github.k33wee.clippy-land.metainfo.xml /app/share/metainfo/io.github.k33wee.clippy-land.metainfo.xml",
         "install -Dm0644 resources/icon.svg /app/share/icons/hicolor/scalable/apps/io.github.k33wee.clippy-land.svg",
@@ -41,8 +42,8 @@
         {
           "type": "git",
           "url": "https://github.com/k33wee/clippy-land.git",
-          "tag": "v0.5.1",
-          "commit": "965f6704508f4e6a68535946a59dcce68e2c86f0"
+          "tag": "v0.5.2",
+          "commit": "b7611e7cda902f50a3332ed2efaf15da2e9fe6ec"
         },
         "cargo-sources.json"
       ]


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Updates Clippy Land to v0.5.2

Changes:
- Fixes a bug where the popup took more than 2 seconds to open due to rendering backend;
- In preview mode the exit keybind is now the 'q' key;
- Adds Polish Translation;

Thanks!