### PR TITLE
Fix Power Monitor AppStream icon packaging

### DIFF
--- a/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
+++ b/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
@@ -37,8 +37,8 @@
         {
           "type": "git",
           "url": "https://github.com/AceMythos/cosmic-power-monitor.git",
-          "tag": "v0.1.3",
-          "commit": "51447459a84b0af0357497a833bef067c1844427"
+          "tag": "v0.1.4",
+          "commit": "328d09f2214b3bd58028aa99ef4107a0a7400e86"
         },
         "cargo-sources.json"
       ]

--- a/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
+++ b/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
@@ -30,13 +30,15 @@
         "cargo --offline build --release --verbose",
         "install -Dm0755 ./target/release/cosmic-power-monitor /app/bin/cosmic-power-monitor",
         "install -Dm0644 ./resources/io.github.AceMythos.cosmic-ext-applet-power-monitor.desktop /app/share/applications/io.github.AceMythos.cosmic-ext-applet-power-monitor.desktop",
-        "install -Dm0644 ./resources/io.github.AceMythos.cosmic-ext-applet-power-monitor.metainfo.xml /app/share/metainfo/io.github.AceMythos.cosmic-ext-applet-power-monitor.metainfo.xml"
+        "install -Dm0644 ./resources/io.github.AceMythos.cosmic-ext-applet-power-monitor.metainfo.xml /app/share/metainfo/io.github.AceMythos.cosmic-ext-applet-power-monitor.metainfo.xml",
+        "install -Dm0644 ./resources/io.github.AceMythos.cosmic-ext-applet-power-monitor.svg /app/share/icons/hicolor/scalable/apps/io.github.AceMythos.cosmic-ext-applet-power-monitor.svg"
       ],
       "sources": [
         {
           "type": "git",
           "url": "https://github.com/AceMythos/cosmic-power-monitor.git",
-          "tag": "v0.1.1"
+          "tag": "v0.1.3",
+          "commit": "51447459a84b0af0357497a833bef067c1844427"
         },
         "cargo-sources.json"
       ]


### PR DESCRIPTION
This fixes store visibility for io.github.AceMythos.cosmic-ext-applet-power-monitor.

Root cause verified from the CI artifact for PR #212 (run 28709111779): appstreamcli compose failed with icon-not-found, so the AppStream metadata was filtered out and the app never appeared in the COSMIC store index.

Changes in this PR:
- install the packaged SVG icon into /app/share/icons/hicolor/scalable/apps/
- update the source reference to a fresh immutable release tag v0.1.3
- pin the exact source commit 51447459a84b0af0357497a833bef067c1844427

The v0.1.3 source release includes the matching desktop/icon metadata so AppStream can resolve the icon correctly during compose.