### PR TITLE
Fix Power Monitor store visibility: add AppStream icon and category

### DIFF
--- a/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
+++ b/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
@@ -37,8 +37,8 @@
         {
           "type": "git",
           "url": "https://github.com/AceMythos/cosmic-power-monitor.git",
-          "tag": "v0.1.3",
-          "commit": "51447459a84b0af0357497a833bef067c1844427"
+          "tag": "v0.1.4",
+          "commit": "328d09f2214b3bd58028aa99ef4107a0a7400e86"
         },
         "cargo-sources.json"
       ]

--- a/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
+++ b/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
@@ -30,13 +30,15 @@
         "cargo --offline build --release --verbose",
         "install -Dm0755 ./target/release/cosmic-power-monitor /app/bin/cosmic-power-monitor",
         "install -Dm0644 ./resources/io.github.AceMythos.cosmic-ext-applet-power-monitor.desktop /app/share/applications/io.github.AceMythos.cosmic-ext-applet-power-monitor.desktop",
-        "install -Dm0644 ./resources/io.github.AceMythos.cosmic-ext-applet-power-monitor.metainfo.xml /app/share/metainfo/io.github.AceMythos.cosmic-ext-applet-power-monitor.metainfo.xml"
+        "install -Dm0644 ./resources/io.github.AceMythos.cosmic-ext-applet-power-monitor.metainfo.xml /app/share/metainfo/io.github.AceMythos.cosmic-ext-applet-power-monitor.metainfo.xml",
+        "install -Dm0644 ./resources/io.github.AceMythos.cosmic-ext-applet-power-monitor.svg /app/share/icons/hicolor/scalable/apps/io.github.AceMythos.cosmic-ext-applet-power-monitor.svg"
       ],
       "sources": [
         {
           "type": "git",
           "url": "https://github.com/AceMythos/cosmic-power-monitor.git",
-          "tag": "v0.1.1"
+          "tag": "v0.1.3",
+          "commit": "51447459a84b0af0357497a833bef067c1844427"
         },
         "cargo-sources.json"
       ]

--- a/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
+++ b/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
@@ -38,7 +38,7 @@
           "type": "git",
           "url": "https://github.com/AceMythos/cosmic-power-monitor.git",
           "tag": "v0.1.4",
-          "commit": "328d09f2214b3bd58028aa99ef4107a0a7400e86"
+          "commit": "328d09f1f08a563567c082e90e66fe019d230da6"
         },
         "cargo-sources.json"
       ]


### PR DESCRIPTION
hey, so the power monitor applet from PR #212 never showed up in the store even though it got merged.

i dug into the CI build log and found that `appstreamcli compose` was failing — no icon file was getting shipped in the flatpak, and there wasnt a valid category set up in the appstream metadata. both of those are needed for the store to pick it up.

this PR points the source to v0.1.4 which has the fix — ships an SVG icon and adds a Utility category to the metainfo. matched the same setup that workspace icons and eyedropper use since those are already working fine in the store.

the source commit is pinned to `328d09f` if anyone wants to check it.