### PR TITLE
Update Workspace Icons to v1.0.2

### DIFF
--- a/app/io.github.crocodile.cosmic-ext-applet-workspace-icons/io.github.crocodile.cosmic-ext-applet-workspace-icons.json
+++ b/app/io.github.crocodile.cosmic-ext-applet-workspace-icons/io.github.crocodile.cosmic-ext-applet-workspace-icons.json
@@ -26,6 +26,7 @@
     "--filesystem=/var/lib/flatpak/app:ro",
     "--filesystem=~/.local/share/flatpak/exports/share/applications:ro",
     "--filesystem=~/.local/share/flatpak/exports/share/icons:ro",
+    "--filesystem=~/.local/share/flatpak/app:ro",
     "--filesystem=~/.local/share/applications:ro",
     "--filesystem=~/.local/share/icons:ro",
     "--filesystem=~/.icons:ro"
@@ -53,7 +54,7 @@
         {
           "type": "git",
           "url": "https://github.com/crocodile/cosmic-ext-applet-workspace-icons.git",
-          "commit": "b1070c45d75e198e4c40cb6cacd998ab43b31b2c"
+          "commit": "622b99abccc69b79db08aa3f38112378dfbae031"
         },
         {
           "type": "file",


### PR DESCRIPTION
Updates Workspace Icons to v1.0.2.

Unfortunately, new users of this applet found a couple of annoying bugs, that had not surfaced during my own testing before.

This release fixes them:

- missing icons for apps installed through Flatpak for current user ([issue #6](https://github.com/crocodile/cosmic-ext-applet-workspace-icons/issues/6)) 
- keeps workspace numbers readable with light accent colours ([issue #7](https://github.com/crocodile/cosmic-ext-applet-workspace-icons/issues/7)).

I built the updated store manifest and tested the Flatpak locally.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
