### PR TITLE
Update Power Monitor to v0.1.8.

### DIFF
--- a/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
+++ b/app/io.github.AceMythos.cosmic-ext-applet-power-monitor/io.github.AceMythos.cosmic-ext-applet-power-monitor.json
@@ -37,8 +37,8 @@
         {
           "type": "git",
           "url": "https://github.com/AceMythos/cosmic-power-monitor.git",
-          "tag": "v0.1.7",
-          "commit": "00b8f15d4fa2a1523936a0ad2d6aa726d8b40c1c"
+          "tag": "v0.1.8",
+          "commit": "47b8fc0c010ad8b7eb94a15c717e785dde5dcd4e"
         },
         "cargo-sources.json"
       ]


### PR DESCRIPTION
Update Power Monitor for the COSMIC™ Desktop to v0.1.8.

### Changes in v0.1.8:
- Fix battery detection on systems with peripheral battery devices (touchpad, keyboard). Uses kernel's scope attribute to prefer the system battery over device batteries.

### Links
- Source: https://github.com/AceMythos/cosmic-power-monitor
- Release: https://github.com/AceMythos/cosmic-power-monitor/releases/tag/v0.1.8

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.