### PR TITLE
Update Workspace Icons to v1.2.0

### DIFF
--- a/app/io.github.crocodile.cosmic-ext-applet-workspace-icons/io.github.crocodile.cosmic-ext-applet-workspace-icons.json
+++ b/app/io.github.crocodile.cosmic-ext-applet-workspace-icons/io.github.crocodile.cosmic-ext-applet-workspace-icons.json
@@ -56,7 +56,7 @@
         {
           "type": "git",
           "url": "https://github.com/crocodile/cosmic-ext-applet-workspace-icons.git",
-          "commit": "8ec0750b836f7008616493912d0fa3c963a74f24"
+          "commit": "72d5adc57881bef38baacd0cd359e1d184ba213c"
         },
         {
           "type": "file",


### PR DESCRIPTION
Updates Workspace Icons to v1.2.0.

What's new:
- Fixes frosted glass blur on settings popup - https://github.com/crocodile/cosmic-ext-applet-workspace-icons/issues/20
- COSMIC-aligned pill colours and urgent-workspace styling (Wayland urgent state)
- Configurable inactive pill contrast to suit different themes
- Fixes icons disappearing while dragging windows - https://github.com/crocodile/cosmic-ext-applet-workspace-icons/issues/30
- Option to show an icon for each window of the same app
- Configurable 1–16 icon limit before remaining icons are shown as +N - https://github.com/crocodile/cosmic-ext-applet-workspace-icons/issues/24

<img width="448" height="480" alt="image" src="https://github.com/user-attachments/assets/438e34ee-4dfa-42ed-895c-1ceb56ebbee1" />

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
