### PR TITLE
Update cosmic-ext-applet-torrent-throttle to v0.2.0

### DIFF
--- a/app/io.github.BlakeGardner.cosmic-ext-applet-torrent-throttle/cargo-sources.json
+++ b/app/io.github.BlakeGardner.cosmic-ext-applet-torrent-throttle/cargo-sources.json
@@ -2758,14 +2758,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/h2/h2-0.4.15.crate",
-        "sha256": "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155",
-        "dest": "cargo/vendor/h2-0.4.15"
+        "url": "https://static.crates.io/crates/h2/h2-0.4.17.crate",
+        "sha256": "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449",
+        "dest": "cargo/vendor/h2-0.4.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155\", \"files\": {}}",
-        "dest": "cargo/vendor/h2-0.4.15",
+        "contents": "{\"package\": \"9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449\", \"files\": {}}",
+        "dest": "cargo/vendor/h2-0.4.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/app/io.github.BlakeGardner.cosmic-ext-applet-torrent-throttle/io.github.BlakeGardner.cosmic-ext-applet-torrent-throttle.json
+++ b/app/io.github.BlakeGardner.cosmic-ext-applet-torrent-throttle/io.github.BlakeGardner.cosmic-ext-applet-torrent-throttle.json
@@ -41,7 +41,7 @@
         {
           "type": "git",
           "url": "https://github.com/BlakeGardner/cosmic-ext-applet-torrent-throttle.git",
-          "commit": "7fd9746131a012445199013c819a2129b712ec57"
+          "commit": "368bb88e4cf79f1f023ad91440fd832d7eb4465b"
         }
       ]
     }


### PR DESCRIPTION
Updates `io.github.BlakeGardner.cosmic-ext-applet-torrent-throttle` to [v0.2.0](https://github.com/BlakeGardner/cosmic-ext-applet-torrent-throttle/releases/tag/v0.2.0):

- Pins the manifest to the v0.2.0 release commit (`368bb88`)
- Regenerates `cargo-sources.json` for the updated `Cargo.lock`

Notable changes in v0.2.0:
- Add Transmission torrent client support
- Support blank credentials for auth-bypassed WebUI

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
