### PR TITLE
papyrus: bump source pin to v1.2.5-4 (fixes Flatpak desktop Exec)

### DIFF
--- a/app/io.github.PSGtatitos.papyrus/io.github.PSGtatitos.papyrus.json
+++ b/app/io.github.PSGtatitos.papyrus/io.github.PSGtatitos.papyrus.json
@@ -163,7 +163,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/PSGtatitos/papyrus.git",
-                    "commit": "0320369628b4834b51258fa5f0d9e36a2e4f47c5"
+                    "commit": "f47be84d358b35a414493ff32db058f1e0f917d3"
                 }
             ]
         }


### PR DESCRIPTION
## Summary
The Papyrus app's Flatpak `.desktop` fails to launch from the COSMIC Store. The exported `.desktop` contains a broken `Exec=... --command=/usr/bin/papyrus`, which doesn't resolve inside the sandbox (the binary is at `/app/bin/papyrus`).

## Root cause
- The manifest pinned Papyrus to commit `0320369628b4834b51258fa5f0d9e36a2e4f47c5`, which **no longer exists** on the remote (force-pushed away).
- As a result the store has been serving a stale build whose `.desktop` used an absolute `Exec=/usr/bin/papyrus`. Flatpak faithfully wraps that into `--command=/usr/bin/papyrus`, which fails.
- The current Papyrus `.desktop` (tag `v1.2.5-4`, commit `f47be84d`) correctly uses `Exec=papyrus`, which Flatpak exports as `--command=papyrus` — working as intended.

## Change
Bump the source pin to `f47be84d358b35a414493ff32db058f1e0f917d3` (tag `v1.2.5-4`).

Fixes PSGtatitos/papyrus#14