### PR TITLE
Update io.github.Zetakai.cosmic-ext-applet-crypto to v0.1.5

### DIFF
--- a/app/io.github.Zetakai.cosmic-ext-applet-crypto/io.github.Zetakai.cosmic-ext-applet-crypto.json
+++ b/app/io.github.Zetakai.cosmic-ext-applet-crypto/io.github.Zetakai.cosmic-ext-applet-crypto.json
@@ -14,7 +14,9 @@
     "--socket=fallback-x11",
     "--share=ipc",
     "--device=dri",
+    "--filesystem=xdg-config/cosmic:rw",
     "--talk-name=com.system76.CosmicSettingsDaemon",
+    "--talk-name=com.system76.CosmicSettingsDaemon.*",
     "--share=network"
   ],
   "build-options": {
@@ -39,9 +41,9 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/Zetakai/cosmic-ext-applet-crypto.git",
-          "tag": "v0.1.0",
-          "commit": "359e7c17b3deab9f2721881a7c6fc85c4e588901"
+          "url": "https://github.com/Gliana-Labs/cosmic-ext-applet-crypto.git",
+          "tag": "v0.1.5",
+          "commit": "ede0c61d23e611417045fd7a52c87c6aacf07313"
         },
         "cargo-sources.json"
       ]


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

Bumps `io.github.Zetakai.cosmic-ext-applet-crypto` from v0.1.0 to v0.1.5. Manifest only — the dependency set is unchanged, so `cargo-sources.json` is untouched.

**v0.1.0 as published here does not work.** Three faults, all specific to the Flatpak — an unsandboxed build is unaffected, which is exactly what hid them from me while developing.

**1. It never starts.** The desktop entry carried `Exec=… %F` and an empty `MimeType`, inherited from the applet template, so flatpak exports it with `--file-forwarding` and `@@ %F @@`. cosmic-panel launches applets with `--socket=inherit-wayland-socket`, and flatpak treats that flag as a filename:

```
io.github.Zetakai.cosmic-ext-applet-crypto: error: Failed to open ‘/home/…/--socket=inherit-wayland-socket’
io.github.Zetakai.cosmic-ext-applet-crypto: exited with code 1
```

An applet takes no file arguments; the stock COSMIC applets carry neither key.

**2. No access to `~/.config/cosmic`.** `flatpak-builder-lint` reports `finish-args-unnecessary-xdg-config-cosmic-rw-access` for that permission so I had dropped it, but `com.system76.Cosmic.BaseApp` grants only `gtk-3.0`, `gtk-4.0`, `kdeglobals` and `color-schemes` — confirmed with `flatpak info --show-permissions`. Without it the desktop theme is unreadable and `cosmic-config` cannot persist the applet's own settings. `cosmic-ext-marketwatch` carries the same permission for the same reason.

**3. It did not follow theme changes while running.** cosmic-settings-daemon publishes a separate bus name per watched config:

```
com.system76.CosmicSettingsDaemon.Config.com.system76.CosmicTheme.Dark.V2
```

`--talk-name` does not match child names without a wildcard, so the change signals never arrived and the applet kept whatever theme it started with. Fixed with `--talk-name=com.system76.CosmicSettingsDaemon.*`.

**Verified, not assumed.** I built this manifest locally with `org.flatpak.Builder` and installed the result. The applet starts, appears in the panel, reads the theme, persists its settings, and now follows theme changes live. Fault 1 is [issue #1](https://github.com/Gliana-Labs/cosmic-ext-applet-crypto/issues/1) from a COSMIC Store user.

Also included:

- **Developer name.** The listing showed *"Crypto Prices Developers"*, an auto-generated fallback — cosmic-store reads the deprecated `developer_name` tag rather than `<developer><name>`. The metainfo now carries both.
- **Renamed** from "Crypto Prices" to "Crypto Ticker".
- **Source moved** to the Gliana-Labs organisation.

**On the App ID:** left as `io.github.Zetakai.…` on purpose — renaming it would mean a new app plus an end-of-life rebase. `github.com/Zetakai/cosmic-ext-applet-crypto` redirects to the new location, so clones resolve; `flatpak-builder-lint` reports `appid-url-not-reachable` for that 301, which is the only thing that objects. Happy to do the rename properly if you would prefer it clean.

**AI disclosure:** this manifest and the applet it packages were written by Claude (Anthropic) from my direction and review, as noted in the commit message.
