### PR TITLE
soulless-launcher: 2.5.2

### DIFF
--- a/app/com.github.hmrdsmoke.soulless-launcher/com.github.hmrdsmoke.soulless-launcher.json
+++ b/app/com.github.hmrdsmoke.soulless-launcher/com.github.hmrdsmoke.soulless-launcher.json
@@ -66,7 +66,7 @@
         {
           "type": "git",
           "url": "https://github.com/hmrdsmoke/Soulless-Launcher",
-          "commit": "d68357617f7977fb3fa9371b0c1e1c1cde687ac3",
+          "commit": "565b53c9859642adf775bb3974d64388fb2c7fab",
           "disable-submodules": false
         },
         "cargo-sources.json"


### PR DESCRIPTION
CLI tool tiles were dead in 2.5.1 (the shell-escape hardening quoted their command into a single literal word). Fixed; hostile names still cannot execute. Pins hmrdsmoke/Soulless-Launcher 565b53c (tag v2.5.2).